### PR TITLE
Add logic to the run_task function for puppet hostname

### DIFF
--- a/lib/beaker/task_helper.rb
+++ b/lib/beaker/task_helper.rb
@@ -48,10 +48,12 @@ INSTALL_BOLT_PP
     on(master, puppet('access', 'login', '--username', user, '--lifetime', lifetime), stdin: password)
   end
 
-  def run_task(task_name:, params: nil, password: DEFAULT_PASSWORD, host: 'localhost', format: 'human')
+  def run_task(task_name:, params: nil, password: DEFAULT_PASSWORD, host: nil, format: 'human')
     output = if pe_install?
+               host = master.hostname if host.nil?
                run_puppet_task(task_name: task_name, params: params, host: host)
              else
+               host = 'localhost' if host.nil?
                run_bolt_task(task_name: task_name, params: params, password: password, host: host)
              end
 


### PR DESCRIPTION
This commit adds logic to the run_task function such that
if the hostname is not supplied, it shall default to either
the master hostname if running against PE, or localhost if
running against bolt.