### PR TITLE
Fix helper for Windows with Bolt 0.16+, support json format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 beaker-task_helper
+
+Accepts Bolt password via the `BEAKER_password` environment variable.

--- a/lib/beaker/task_helper.rb
+++ b/lib/beaker/task_helper.rb
@@ -100,7 +100,7 @@ INSTALL_BOLT_PP
       bolt_full_cli << ' --transport winrm --user Administrator'
     end
     puts "BOLT_CLI: #{bolt_full_cli}" if ENV['BEAKER_debug']
-    on(default, bolt_full_cli, acceptable_exit_codes: [0, 1]).stdout
+    on(default, bolt_full_cli, acceptable_exit_codes: [0, 1, 2]).stdout
   end
 
   def run_puppet_task(task_name:, params: nil, host: 'localhost', format: 'human')

--- a/lib/beaker/task_helper.rb
+++ b/lib/beaker/task_helper.rb
@@ -69,16 +69,23 @@ INSTALL_BOLT_PP
     if fact_on(default, 'osfamily') == 'windows'
       bolt_path = '/cygdrive/c/Program\ Files/Puppet\ Labs/Puppet/sys/ruby/bin/bolt.bat'
       module_path = 'C:/ProgramData/PuppetLabs/code/modules'
+
+      if Puppet::Util::Package.versioncmp(BOLT_VERSION, '0.15.0') > 0
+        check = '--no-ssl'
+      else
+        check = '--insecure'
+      end
     else
       bolt_path = '/opt/puppetlabs/puppet/bin/bolt'
       module_path = '/etc/puppetlabs/code/modules'
+
+      if Puppet::Util::Package.versioncmp(BOLT_VERSION, '0.15.0') > 0
+        check = '--no-host-key-check'
+      else
+        check = '--insecure'
+      end
     end
 
-    if Puppet::Util::Package.versioncmp(BOLT_VERSION, '0.15.0') > 0
-      check = '--no-host-key-check'
-    else
-      check = '--insecure'
-    end
 
     bolt_full_cli = "#{bolt_path} task run #{task_name} #{check} -m #{module_path} --nodes #{host} --password #{password}" # rubocop:disable Metrics/LineLength
     bolt_full_cli << if params.class == Hash

--- a/lib/beaker/task_helper.rb
+++ b/lib/beaker/task_helper.rb
@@ -8,10 +8,10 @@ module Beaker::TaskHelper # rubocop:disable Style/ClassAndModuleChildren
     (on default, puppet('--version')).output.chomp
   end
 
-  DEFAULT_PASSWORD = if default[:hypervisor] == 'vagrant'
+  DEFAULT_PASSWORD = if ENV.has_key?('BEAKER_password')
+                       ENV['BEAKER_password']
+                     elsif default[:hypervisor] == 'vagrant'
                        'puppet'
-                     elsif default[:hypervisor] == 'vcloud' || default[:hypervisor] == 'vmpooler'
-                       'Qu@lity!'
                      else
                        'root'
                      end

--- a/spec/beaker/task_helper_spec.rb
+++ b/spec/beaker/task_helper_spec.rb
@@ -1,12 +1,13 @@
 require 'spec_helper_acceptance'
 
 RSpec.describe Beaker::TaskHelper do
-  it 'returns correct summary line' do
-    describe 'with default values' do
-      expect(task_summary_line).to be 'Job completed. 1/1 nodes succeeded|Ran on 1 node'
+  context 'returns correct summary line' do
+    it 'with default values' do
+      expect(task_summary_line).to eq 'Job completed. 1/1 nodes succeeded|Ran on 1 node'
     end
-    describe 'with 3 total hosts and 2 success' do
-      expect(task_summary_line(3, 2)).to be 'Job completed. 2/3 nodes succeeded|Ran on 3 node'
+    it 'with 3 total hosts and 2 success' do
+      expect(task_summary_line(total_hosts: 3, success_hosts: 2))
+        .to eq 'Job completed. 2/3 nodes succeeded|Ran on 3 node'
     end
   end
 end


### PR DESCRIPTION
In Bolt 0.16.0, the `--insecure` flag was split into
`--no-host-key-check` for SSH and `--no-ssl` for WinRM. Fix running over
WinRM for recent versions of Bolt.

Also fix passing `format: 'json'` to `run_task`.