### PR TITLE
(PE-23296) Add in logic incase default role isn't used

### DIFF
--- a/lib/beaker-task_helper.rb
+++ b/lib/beaker-task_helper.rb
@@ -10,6 +10,8 @@ module Beaker::TaskHelper # rubocop:disable Style/ClassAndModuleChildren
 
   DEFAULT_PASSWORD = if ENV.has_key?('BEAKER_password')
                        ENV['BEAKER_password']
+                     elsif !defined?(default)
+                       'root'
                      elsif default[:hypervisor] == 'vagrant'
                        'puppet'
                      else


### PR DESCRIPTION
If a default Beaker role is not used, there is a runtime error when the default password is defined.
This PR changes the default password logic, so if the default Beaker role is not we no longer get a runtime error.
