### PR TITLE
PE-23297 Add option to pass in the module path

### DIFF
--- a/lib/beaker-task_helper.rb
+++ b/lib/beaker-task_helper.rb
@@ -68,10 +68,12 @@ INSTALL_BOLT_PP
   end
 
   def run_bolt_task(task_name:, params: nil, password: DEFAULT_PASSWORD,
-                    host: 'localhost', format: 'human')
+                    host: 'localhost', format: 'human', module_path: '/etc/puppetlabs/code/modules')
     if fact_on(default, 'osfamily') == 'windows'
       bolt_path = '/cygdrive/c/Program\ Files/Puppet\ Labs/Puppet/sys/ruby/bin/bolt.bat'
-      module_path = 'C:/ProgramData/PuppetLabs/code/modules'
+      unless module_path
+        module_path = 'C:/ProgramData/PuppetLabs/code/modules'
+      end
 
       if version_is_less('0.15.0', BOLT_VERSION)
         check = '--no-ssl'
@@ -80,7 +82,6 @@ INSTALL_BOLT_PP
       end
     else
       bolt_path = '/opt/puppetlabs/puppet/bin/bolt'
-      module_path = '/etc/puppetlabs/code/modules'
 
       if version_is_less('0.15.0', BOLT_VERSION)
         check = '--no-host-key-check'


### PR DESCRIPTION
Add an option to pass in the module path from the calling method in the
bolt task helper to help with running tasks that are not in the default
path