### PR TITLE
PE-23297 Fix the default module_path

### DIFF
--- a/lib/beaker-task_helper.rb
+++ b/lib/beaker-task_helper.rb
@@ -68,12 +68,10 @@ INSTALL_BOLT_PP
   end
 
   def run_bolt_task(task_name:, params: nil, password: DEFAULT_PASSWORD,
-                    host: 'localhost', format: 'human', module_path: '/etc/puppetlabs/code/modules')
+                    host: 'localhost', format: 'human', module_path: nil)
     if fact_on(default, 'osfamily') == 'windows'
       bolt_path = '/cygdrive/c/Program\ Files/Puppet\ Labs/Puppet/sys/ruby/bin/bolt.bat'
-      unless module_path
-        module_path = 'C:/ProgramData/PuppetLabs/code/modules'
-      end
+      module_path ||= 'C:/ProgramData/PuppetLabs/code/modules'
 
       if version_is_less('0.15.0', BOLT_VERSION)
         check = '--no-ssl'
@@ -82,6 +80,7 @@ INSTALL_BOLT_PP
       end
     else
       bolt_path = '/opt/puppetlabs/puppet/bin/bolt'
+      module_path ||='/etc/puppetlabs/code/modules'
 
       if version_is_less('0.15.0', BOLT_VERSION)
         check = '--no-host-key-check'


### PR DESCRIPTION
Set the default module_path to 'nil' so that the path will be set
downstream depending on the OS if no path was passed down from the
caller