### PR TITLE
(BOLT-229) Add a helper to generate bolt inventory from Beaker

### DIFF
--- a/lib/beaker-task_helper/inventory.rb
+++ b/lib/beaker-task_helper/inventory.rb
@@ -1,0 +1,79 @@
+require 'beaker'
+
+module Beaker
+  module TaskHelper
+    module Inventory
+      # This attempts to make a bolt inventory hash from beakers hosts
+      # roles should be targetable by bolt as groups
+      def hosts_to_inventory
+        groups = []
+
+        def add_node(node, group_name, groups)
+          if group_name =~ %r{\A[a-z0-9_]+\Z}
+            group = groups.find { |g| g['name'] == group_name }
+            unless group
+              group = { 'name' => group_name, 'nodes' => [] }
+              groups << group
+            end
+            group['nodes'] << node
+          else
+            puts "invalid group name #{group_name} skipping"
+          end
+        end
+
+        nodes = hosts.map do |host|
+          # Make sure nodes with IPs have unique target names
+          node_name = host[:ip] ? "#{host[:ip]}?n=#{host.hostname}" : host.hostname
+
+          if host[:platform] =~ %r{windows}
+            config = { 'transport' => 'winrm',
+                       'winrm' => { 'ssl' => false,
+                                    'user' => host[:user],
+                                    'password' => ENV['BEAKER_password'] } }
+          else
+            config = { 'transport' => 'ssh',
+                       'ssh' => { 'host-key-check' => false } }
+            %i[password user port].each do |k|
+              config['ssh'][k.to_s] = host[:ssh][k] if host[:ssh][k]
+            end
+
+            case host[:hypervisor]
+            when 'docker'
+              nil
+            when 'vagrant'
+              key = nil
+              keys = host.connection.instance_variable_get(:@ssh).options[:keys]
+              key = keys.first if keys
+              config['ssh']['private-key'] = key if key
+            when 'vmpooler'
+              key = nil
+              keys = host[:ssh][:keys]
+              key = keys.first if keys
+              config['ssh']['private-key'] = key if key
+            else
+              raise "Can't generate inventory for platform #{host[:platform]} hypervisor #{host[:hypervisor]}"
+            end
+          end
+
+          # make alias groups for each role
+          host[:roles].each do |role|
+            add_node(node_name, role, groups)
+          end
+
+          {
+            'name' => node_name,
+            'config' => config
+          }
+        end
+
+        { 'nodes' => nodes,
+          'groups' => groups,
+          'config' => {
+            'ssh' => {
+              'host-key-check' => false
+            }
+          } }
+      end
+    end
+  end
+end


### PR DESCRIPTION
This attempts to inspect the host object and extract ssh connection
information. The support is hypervisor specific for now. This creates an
inventory that can be passed to the BoltSpec::Run helpers bypassing the
run_task helpers included in this library