### PR TITLE
(maint) - Release to include CHANGELOG entry for previous release (1.5.0).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.5.1
+### Added
+- Include CHANGELOG.md entry for previous release.
+
 ## 1.5.0
 ### Added
 - `Beaker::TaskHelper::Inventory.hosts_to_inventory` creates an inventory hash from beaker hosts.


### PR DESCRIPTION
1.5.0 was released without an entry to the CHANGELOG. Releasing this gem to include this.