### PR TITLE
(BOLT-741) Support AlwaysBeScheduling hypervisor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.5.2
+### Added
+- Add support for AlwaysBeScheduling hypervisor to `Beaker::TaskHelper::Inventory.hosts_to_inventory`.
+
 ## 1.5.1
 ### Added
 - Include CHANGELOG.md entry for previous release.

--- a/lib/beaker-task_helper/inventory.rb
+++ b/lib/beaker-task_helper/inventory.rb
@@ -45,7 +45,7 @@ module Beaker
               keys = host.connection.instance_variable_get(:@ssh).options[:keys]
               key = keys.first if keys
               config['ssh']['private-key'] = key if key
-            when 'vmpooler'
+            when 'vmpooler', 'abs'
               key = nil
               keys = host[:ssh][:keys]
               key = keys.first if keys


### PR DESCRIPTION
BOLT-741 adds jenkins testing for install_agent::install on osx and windows targets. The preferred hypervisor for module CI jobs is abs. This commit handles abs hypervisor by extracting ssh key location the same way as for vmpooler hypervisor.