### PR TITLE
(maint) Scrape peconf for console password

### DIFF
--- a/lib/beaker-task_helper.rb
+++ b/lib/beaker-task_helper.rb
@@ -65,6 +65,8 @@ INSTALL_BOLT_PP
   end
 
   def run_puppet_access_login(user:, password: '~!@#$%^*-/ aZ', lifetime: '5y')
+    peconf_password = get_unwrapped_pe_conf_value("console_admin_password")
+    password = peconf_password if peconf_password != nil && peconf_password != ""
     on(master, puppet('access', 'login', '--username', user, '--lifetime', lifetime), stdin: password)
   end
 


### PR DESCRIPTION
If the peconf is set to a password that is not the default beaker console password (i.e. frankenbuilds), password verification fails and the run hangs in this state. This was seen while attempting to create a pe_compiler node through a franeknbuild, where `run_puppet_access_login` is called with default values instead of frankenbuilder's admin pass.

This pr scrapes peconf for a password and replaces the default is there is one available