### PR TITLE
(maint) Update helper to be compatible with Bolt 2.0 changes

### DIFF
--- a/lib/beaker-task_helper.rb
+++ b/lib/beaker-task_helper.rb
@@ -64,6 +64,14 @@ INSTALL_BOLT_PP
     ENV['PUPPET_INSTALL_TYPE'] =~ %r{pe}i
   end
 
+  def target_flag
+    if version_is_less('1.18.0', BOLT_VERSION)
+      '--targets'
+    else
+      '--nodes'
+    end
+  end
+
   def run_puppet_access_login(user:, password: '~!@#$%^*-/ aZ', lifetime: '5y')
     peconf_password = get_unwrapped_pe_conf_value("console_admin_password")
     password = peconf_password if peconf_password != nil && peconf_password != ""
@@ -141,7 +149,7 @@ INSTALL_BOLT_PP
     end
 
     bolt_full_cli = "#{bolt_path} task run #{task_name} #{check} -m #{module_path} " \
-                    "--nodes #{host} --password #{password}"
+                    "#{target_flag} #{host} --password #{password}"
     bolt_full_cli << " --format #{format}" if format != 'human'
     bolt_full_cli << if params.class == Hash
                        " --params '#{params.to_json}'"
@@ -157,7 +165,7 @@ INSTALL_BOLT_PP
   end
 
   def run_puppet_task(task_name:, params: nil, host: '127.0.0.1', format: 'human')
-    args = ['task', 'run', task_name, '--nodes', host]
+    args = ['task', 'run', task_name, target_flag, host]
     if params.class == Hash
       args << '--params'
       args << params.to_json
@@ -178,7 +186,7 @@ INSTALL_BOLT_PP
   end
 
   def task_summary_line(total_hosts: 1, success_hosts: 1)
-    "Job completed. #{success_hosts}/#{total_hosts} nodes succeeded|Ran on #{total_hosts} node"
+    "Job completed. #{success_hosts}/#{total_hosts} targets succeeded|Ran on #{total_hosts} target"
   end
 end
 

--- a/lib/beaker-task_helper/inventory.rb
+++ b/lib/beaker-task_helper/inventory.rb
@@ -3,6 +3,14 @@ require 'beaker'
 module Beaker
   module TaskHelper
     module Inventory
+      def target_key
+        if version_is_less('1.18.0', BOLT_VERSION)
+          'targets'
+        else
+          'nodes'
+        end
+      end
+
       # This attempts to make a bolt inventory hash from beakers hosts
       # roles should be targetable by bolt as groups
       def hosts_to_inventory
@@ -12,10 +20,10 @@ module Beaker
           if group_name =~ %r{\A[a-z0-9_]+\Z}
             group = groups.find { |g| g['name'] == group_name }
             unless group
-              group = { 'name' => group_name, 'nodes' => [] }
+              group = { 'name' => group_name, target_key => [] }
               groups << group
             end
-            group['nodes'] << node
+            group[target_key] << node
           else
             puts "invalid group name #{group_name} skipping"
           end
@@ -66,7 +74,7 @@ module Beaker
           }
         end
 
-        { 'nodes' => nodes,
+        { target_key => nodes,
           'groups' => groups,
           'config' => {
             'ssh' => {

--- a/spec/beaker/task_helper_spec.rb
+++ b/spec/beaker/task_helper_spec.rb
@@ -3,11 +3,11 @@ require 'spec_helper_acceptance'
 RSpec.describe Beaker::TaskHelper do
   context 'returns correct summary line' do
     it 'with default values' do
-      expect(task_summary_line).to eq 'Job completed. 1/1 nodes succeeded|Ran on 1 node'
+      expect(task_summary_line).to eq 'Job completed. 1/1 targets succeeded|Ran on 1 target'
     end
     it 'with 3 total hosts and 2 success' do
       expect(task_summary_line(total_hosts: 3, success_hosts: 2))
-        .to eq 'Job completed. 2/3 nodes succeeded|Ran on 3 node'
+        .to eq 'Job completed. 2/3 targets succeeded|Ran on 3 target'
     end
   end
 end


### PR DESCRIPTION
This updates the helper to use `targets` instead of `nodes` where
appropriate both in passing flags on the commandline and in writing out
inventory files.