### PR TITLE
(maint) Use installed bolt version instead of default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 # Change Log
+
+### 1.9.0
+### Added
+- Added `BEAKER_BOLT_VERSION` environment variable to set the version of Bolt used to generate an inventory file.
+
+### Changed
+- Updated the helper to query the version of Bolt installed on the Beaker host when generating an inventory file.
+
 ### 1.8.0
 ### Changed
 - Updated the helper to be compatible with [Bolt 2.0 changes](https://github.com/puppetlabs/bolt/blob/master/CHANGELOG.md). *Bolt 2.0 introduced some [backwards-incompatible changes](https://github.com/puppetlabs/bolt/blob/master/CHANGELOG.md#bolt-200-2020-02-19) that you should be aware of before upgrading to this version.*
@@ -8,7 +16,6 @@
 - `.ssh` directory path on OSX 10.12/10.13/10.14 and Solaris 10
 - Puppet 6 collection handling fix
 - PE `puppet access login` fixes
-
 
 ## 1.7.0
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 beaker-task_helper
 
 Accepts Bolt password via the `BEAKER_password` environment variable.
+Accepts Bolt version via the `BEAKER_BOLT_VERSION` environment variable.

--- a/lib/beaker-task_helper.rb
+++ b/lib/beaker-task_helper.rb
@@ -26,14 +26,19 @@ module Beaker::TaskHelper # rubocop:disable Style/ClassAndModuleChildren
     end
   end
 
+  # Returns the version of Bolt installed on the beakerhost. Used to determine
+  # which inventory file version to generate.
+  #
   def self.bolt_version(beakerhost = nil)
+    return ENV['BEAKER_BOLT_VERSION'] if ENV['BEAKER_BOLT_VERSION']
+
     beakerhost ||= default
     begin
       on(beakerhost, "#{bolt_path} --version")
     rescue Beaker::Host::CommandFailure
-      # If bolt isn't installed, use the latest version
-      #on(beakerhost, "gem query --name-matches ^bolt$ -r -q").scan(/\d+/).join('.')
-      '2.10.0'
+      # If bolt isn't installed, default to 1.18.0 which is the latest version
+      # to support only v1 inventory
+      '1.18.0'
     end
   end
 

--- a/lib/beaker-task_helper/inventory.rb
+++ b/lib/beaker-task_helper/inventory.rb
@@ -1,14 +1,23 @@
 require 'beaker'
+require 'beaker-task_helper'
 
 module Beaker
   module TaskHelper
     module Inventory
-      def target_key
-        if version_is_less('1.18.0', BOLT_VERSION)
-          'targets'
+      def inventory_version
+        if version_is_less('1.18.0', Beaker::TaskHelper.bolt_version)
+          2
         else
-          'nodes'
+          1
         end
+      end
+
+      def target_key
+        inventory_version == 2 ? 'targets' : 'nodes'
+      end
+      
+      def uri_key
+        inventory_version == 2 ? 'uri' : 'name'
       end
 
       # This attempts to make a bolt inventory hash from beakers hosts
@@ -69,18 +78,20 @@ module Beaker
           end
 
           {
-            'name' => node_name,
+            uri_key => node_name,
             'config' => config
           }
         end
 
-        { target_key => nodes,
-          'groups' => groups,
-          'config' => {
-            'ssh' => {
-              'host-key-check' => false
-            }
-          } }
+        inv = { target_key => nodes,
+                'groups' => groups,
+                'config' => {
+                  'ssh' => {
+                    'host-key-check' => false
+                  }
+                } }
+        inv.merge!({'version' => 2}) if inventory_version == 2
+        inv
       end
     end
   end

--- a/lib/beaker-task_helper/inventory.rb
+++ b/lib/beaker-task_helper/inventory.rb
@@ -50,8 +50,11 @@ module Beaker
           else
             config = { 'transport' => 'ssh',
                        'ssh' => { 'host-key-check' => false } }
-            %i[password user port].each do |k|
+            %i[password user].each do |k|
               config['ssh'][k.to_s] = host[:ssh][k] if host[:ssh][k]
+            end
+            if host[:ssh][:port]
+              config['ssh']['port'] = host[:ssh][:port].to_i
             end
 
             case host[:hypervisor]


### PR DESCRIPTION
Previously this used the default bolt version, stored in constant
`BOLT_VERSION`, to build bolt commands. This now gets the installed
bolt version when building bolt inventory and commands.