### PR TITLE
(maint) Add 'none' case for hypervisor

### DIFF
--- a/lib/beaker-task_helper/inventory.rb
+++ b/lib/beaker-task_helper/inventory.rb
@@ -58,7 +58,7 @@ module Beaker
             end
 
             case host[:hypervisor]
-            when 'docker'
+            when 'docker', 'none'
               nil
             when 'vagrant'
               key = nil


### PR DESCRIPTION
The none case would enable the test from having to request a new VM each time.